### PR TITLE
Version sort fix

### DIFF
--- a/BoxHandler.go
+++ b/BoxHandler.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sort"
 )
 
 type BoxHandler struct {
@@ -203,15 +204,10 @@ func (bh *BoxHandler) createBoxes(sb []SimpleBox, port int, hostname *string) {
 			boxes[b.Username] = make(map[string]Box)
 		}
 
-		box.CurrentVersion = nil
-		for _, v := range box.Versions {
-			if box.CurrentVersion == nil {
-				box.CurrentVersion = &v
-			}
-			if version.Compare(box.CurrentVersion.Version, v.Version, "<") {
-				box.CurrentVersion = &v
-			}
-		}
+		sort.Slice(box.Versions[:], func(i, j int) bool {
+			return version.Compare(box.Versions[i].Version, box.Versions[j].Version, ">")
+		})
+		box.CurrentVersion = &box.Versions[0]
 
 		boxes[b.Username][b.Boxname] = box
 	}

--- a/BoxHandler_test.go
+++ b/BoxHandler_test.go
@@ -51,17 +51,43 @@ func TestSetsCorrectBoxAsCurrent(t *testing.T) {
 	assert := assert.New(t)
 	bh := BoxHandler{}
 	boxes := []SimpleBox{SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "2.0"},
-		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "1.0"},
-		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "4.1"}}
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "4.1"},
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "1.0"}}
 	host := "localhost"
 	bh.createBoxes(boxes, 80, &host)
 	assert.Equal("4.1", bh.GetBox("benphegan", "dev").CurrentVersion.Version)
 }
 
+func TestSetsCorrectBoxAsCurrentBasedOnMinor(t *testing.T) {
+	assert := assert.New(t)
+	bh := BoxHandler{}
+	boxes := []SimpleBox{
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.3.9"},
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.4.10"},
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.3.100"}}
+	host := "localhost"
+	bh.createBoxes(boxes, 80, &host)
+	assert.Equal("0.4.10", bh.GetBox("benphegan", "dev").CurrentVersion.Version)
+}
+
+func TestSetsCorrectBoxAsCurrentBasedOnPatch(t *testing.T) {
+	assert := assert.New(t)
+	bh := BoxHandler{}
+	boxes := []SimpleBox{
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.3.9"},
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.3.100"},
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "0.3.10"}}
+	host := "localhost"
+	bh.createBoxes(boxes, 80, &host)
+	assert.Equal("0.3.100", bh.GetBox("benphegan", "dev").CurrentVersion.Version)
+}
+
+
 func TestCorrectProvidersCreated(t *testing.T) {
 	assert := assert.New(t)
 	bh := BoxHandler{}
-	boxes := []SimpleBox{SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "2.0"},
+	boxes := []SimpleBox{
+		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "2.0"},
 		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "vmware", Version: "1.0"},
 		SimpleBox{Boxname: "dev", Username: "benphegan", Provider: "virtualbox", Version: "4.1"}}
 	host := "localhost"

--- a/HomePageTemplate.go
+++ b/HomePageTemplate.go
@@ -30,7 +30,7 @@ func (ht *HomePageTemplate) GetDefaultTemplateString() string {
 		<h2>Server Configuration</h2>
 		vagrantshadow will attempt to index and serve any file in the following filename structure:
 		<p/>
-			username-VAGRANTSHADOW-boxname__provider__versionstring.box
+			username-VAGRANTSHADOW-boxname__versionstring__provider.box
 		<p/>
 		versionstring can be any standard version string.  By default, vagrantshadow will make the highest version in the indexed directories the "current" version of a particular box.
 		<p/>


### PR DESCRIPTION
fixes the version sorting mentioned in https://github.com/BenPhegan/vagrantshadow/issues/11 and also corrects the home page template to have the correct file name template